### PR TITLE
test: remove native token config test

### DIFF
--- a/template/ts/files/tests/helixconf.test.ts
+++ b/template/ts/files/tests/helixconf.test.ts
@@ -164,12 +164,6 @@ describe("helixconf_test", () => {
 });
 
 describe.each(HelixChain.chains())(`$_data.name`, ({ tokens, code, id, rpcs, couples }) => {
-  if (couples.length) {
-    test('Native token should be configured', () => {
-      expect(tokens.some((t) => t.type === 'native')).toBeTruthy();
-    });
-  }
-
   describe.each(tokens)(`$symbol`, (token) => {
     test("The logo field should be configured", () => {
       expect(token.logo).toBeDefined();


### PR DESCRIPTION
There is no need to check the configuration of native token anymore. If it is not used, you don’t need to configure native token.